### PR TITLE
stream/widgets.vala public Stream() to StreamBabe

### DIFF
--- a/stream.vala
+++ b/stream.vala
@@ -19,7 +19,7 @@ using TagLib;
 
 namespace BabeStream
 {
-	public class Stream	: GLib.Object
+	public class StreamBabe	: GLib.Object
 	{
 		public string song_uri;
 		public Gst.Element playbin;		 
@@ -34,7 +34,7 @@ namespace BabeStream
 		public	int64 start;
 		public	int64 end;
 	
-		public Stream()
+		public StreamBabe()
 		{
 			query = new Gst.Query.seeking (Gst.Format.TIME);
 			this.seek_enabled = false;

--- a/widgets.vala
+++ b/widgets.vala
@@ -29,7 +29,7 @@ const string playlist_path="./Playlist/";
 
 public class BabeWindow : Gtk.Window //creates main window with all widgets alltogether...not ideal but...
 {
-	public Stream babe_stream;
+	public StreamBabe babe_stream;
 	public LastFm artwork;
 	public BList main_list;
 	public BList queue_list;
@@ -152,7 +152,7 @@ public class BabeWindow : Gtk.Window //creates main window with all widgets allt
 		cover=new Gtk.Image();
 		this.cover.set_from_file ("img/babe.png");
 
-        babe_stream=new Stream(); //this is the main pipeline for streaming
+        babe_stream=new StreamBabe(); //this is the main pipeline for streaming
         artwork = new LastFm(); //this is to get the album art
         babe_lyric= new LyricsManiaFetcher();
         


### PR DESCRIPTION
This resolved the following compilation error on my Debian Jessie host:

```
widgets.vala:32.9-32.14: error: `Stream' is an ambiguous reference
between `Gst.Stream' and `BabeStream.Stream'
   public Stream babe_stream;
             ^^^^^^
```

PS: I wish you best luck with your :smiley: 
